### PR TITLE
feat: Add loading spinner to floating GUI left panel

### DIFF
--- a/src/renderer/src/pages/panel.tsx
+++ b/src/renderer/src/pages/panel.tsx
@@ -12,6 +12,7 @@ import { ContinueConversation } from "@renderer/components/continue-conversation
 import { useConversationActions, useConversationState, useConversation } from "@renderer/contexts/conversation-context"
 import { PanelDragBar } from "@renderer/components/panel-drag-bar"
 import { useConfigQuery } from "@renderer/lib/query-client"
+import { Spinner } from "@renderer/components/ui/spinner"
 
 
 
@@ -466,15 +467,24 @@ export function Component() {
       ) : (
         <div className="flex h-full w-full rounded-xl liquid-glass transition-all duration-300 glass-text-strong">
           <div className="flex shrink-0">
-            {mcpMode && (
+            {/* Show loading spinner when processing */}
+            {(transcribeMutation.isPending || mcpTranscribeMutation.isPending || textInputMutation.isPending || mcpTextInputMutation.isPending) ? (
               <div className="flex items-center justify-center w-8 h-full liquid-glass-subtle rounded-l-xl">
-                <div className="w-2 h-2 bg-primary rounded-full animate-pulse shadow-lg" title="MCP Tool Mode" />
+                <Spinner className="w-3 h-3" />
               </div>
-            )}
-            {isConversationActive && !mcpMode && (
-              <div className="flex items-center justify-center w-8 h-full liquid-glass-subtle rounded-l-xl">
-                <div className="w-2 h-2 bg-green-500 rounded-full shadow-lg" title="Conversation Active" />
-              </div>
+            ) : (
+              <>
+                {mcpMode && (
+                  <div className="flex items-center justify-center w-8 h-full liquid-glass-subtle rounded-l-xl">
+                    <div className="w-2 h-2 bg-primary rounded-full animate-pulse shadow-lg" title="MCP Tool Mode" />
+                  </div>
+                )}
+                {isConversationActive && !mcpMode && (
+                  <div className="flex items-center justify-center w-8 h-full liquid-glass-subtle rounded-l-xl">
+                    <div className="w-2 h-2 bg-green-500 rounded-full shadow-lg" title="Conversation Active" />
+                  </div>
+                )}
+              </>
             )}
           </div>
           <div


### PR DESCRIPTION
## Summary

Adds a loading spinner to the floating GUI's left panel that provides visual feedback during processing states.

## Changes

- **Added Spinner Import**: Imported the existing `Spinner` component from `@renderer/components/ui/spinner`
- **Enhanced Left Panel Logic**: Added conditional rendering to show spinner during any processing state
- **Universal Loading States**: Spinner appears when any of these operations are pending:
  - Voice transcription (`transcribeMutation.isPending`)
  - MCP transcription (`mcpTranscribeMutation.isPending`) 
  - Text input processing (`textInputMutation.isPending`)
  - MCP text input processing (`mcpTextInputMutation.isPending`)
- **Maintains Fallback**: Original circle indicators (MCP mode, conversation active) still show when not processing

## Features

✅ **Universal Loading Indicator**: Works in both normal transcription mode and agent mode
✅ **Consistent Positioning**: Uses the same left panel space as existing indicators
✅ **Proper Sizing**: Sized at `w-3 h-3` (12px) to fit well in the 8px wide panel
✅ **Smooth Transitions**: Inherits existing transition classes for smooth state changes
✅ **Preserves Waveform**: The waveform visualization on the right remains unchanged

## Testing

- [x] Code compiles without errors
- [x] Spinner component exists and is properly exported
- [x] CSS dependencies are in place
- [x] Maintains existing UI behavior when not loading

## Screenshots

The spinner will appear in the left panel (where the circle indicators currently are) during any processing operation, providing clear visual feedback to users about system activity.

---

Resolves the request to add a loading spinner to the floating GUI with waveform on the left.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author